### PR TITLE
Add hyperparameter optimization

### DIFF
--- a/configs/cnn10-hpopt.yaml
+++ b/configs/cnn10-hpopt.yaml
@@ -1,0 +1,52 @@
+project: ldct-benchmark
+program: ldctbench-train
+command:
+  - ${program}
+  - ${args_no_boolean_flags}
+description: Hyperparameter optimization for CNN-10
+method: bayes
+metric:
+  goal: maximize
+  name: SSIM
+name: cnn10-hpopt
+parameters:
+  adam_b1:
+    value: 0.9
+  adam_b2:
+    value: 0.999
+  data_norm:
+    value: meanstd
+  data_subset:
+    value: 1
+  devices:
+    value: 0
+  dryrun:
+    value: false
+  iterations_before_val:
+    value: 1000
+  lr:
+    distribution: log_uniform_values
+    max: 0.01
+    min: 1e-05
+  max_iterations:
+    distribution: int_uniform
+    max: 100000
+    min: 1000
+  mbs:
+    distribution: int_uniform
+    max: 128
+    min: 2
+  num_workers:
+    value: 4
+  optimizer:
+    value: adam
+  patchsize:
+    distribution: int_uniform
+    max: 128
+    min: 32
+  seed:
+    value: 1332
+  trainer:
+    value: cnn10
+  valsamples:
+    value: 8

--- a/docs/examples/hyperparameter_optimization.md
+++ b/docs/examples/hyperparameter_optimization.md
@@ -1,0 +1,102 @@
+!!! info "Prerequisite"
+    This example assumes you have:
+
+    1. The package `ldct-benchmark` installed
+    2. The LDCT dataset downloaded to a folder `path/to/ldct-data`
+    3. The environment variable `LDCTBENCH_DATAFOLDER` set to that folder
+    
+    Please refer to [Getting Started](../getting_started.md) for instructions on how to do these steps.
+
+## What is hyperparameter optimization?
+Hyperparameter optimization is the process of finding the optimal configuration of hyperparameters for a machine learning model. In deep neural networks, hyperparameters such as learning rate, batch size, or weights of different loss terms can greatly influence model performance. Therefore, proper tuning of these parameters is crucial. The four most common methods for hyperparameter optimization are human optimization, grid search, randomized search, and Bayesian optimization.
+
+1. **Human optimization:** Manual fine-tuning involves iteratively adjusting hyperparameters based on intuition, experience, and observation of model performance. While this approach leverages domain expertise, it is time-consuming, subjective, and often fails to explore the hyperparameter space thoroughly.
+
+2. **Grid Search:** Grid search systematically evaluates every combination of predefined hyperparameter values. It's comprehensive but computationally expensive, especially with many hyperparameters, as the number of combinations grows exponentially.
+
+3. **Randomized Search:** Randomized search samples hyperparameter values from specified distributions rather than exhaustively trying all combinations. It is generally preferred over grid search[^1].
+
+4. **Bayesian Optimization:** Bayesian optimization builds a surrogate model of the objective function and uses an acquisition function to determine which hyperparameter combinations to try next. Bayesian optimization has been shown to outperform other optimization methods on a variety of DNN and dataset configurations[^2][^3].
+
+## Define hyperparameters to optimize
+As for logging, we use [Weights & Biases](https://docs.wandb.ai/tutorials/sweeps/) to tune hyperparameters. To configure a hyperparameter optimization run (sweep) you need to define a configuration file in YAML format. The configuration file specifies the optimization method, hyperparameters to tune, and their respective distributions. To optmize the CNN-10 model, we could use the following config file:
+
+
+=== "configs/cnn10-hpopt.yaml"
+    
+    ```yaml
+    project: ldct-benchmark
+    program: ldctbench-train
+    command:
+    - ${program}
+    - ${args_no_boolean_flags}
+    description: Hyperparameter optimization for CNN-10
+    method: bayes
+    metric:
+        goal: maximize
+        name: SSIM
+    name: cnn10-hpopt
+    parameters:
+    adam_b1:
+        value: 0.9
+    adam_b2:
+        value: 0.999
+    data_norm:
+        value: meanstd
+    data_subset:
+        value: 1
+    devices:
+        value: 0
+    dryrun:
+        value: false
+    iterations_before_val:
+        value: 1000
+    lr:
+        distribution: log_uniform_values
+        max: 0.01
+        min: 1e-05
+    max_iterations:
+        distribution: int_uniform
+        max: 100000
+        min: 1000
+    mbs:
+        distribution: int_uniform
+        max: 128
+        min: 2
+    num_workers:
+        value: 4
+    optimizer:
+        value: adam
+    patchsize:
+        distribution: int_uniform
+        max: 128
+        min: 32
+    seed:
+        value: 1332
+    trainer:
+        value: cnn10
+    valsamples:
+        value: 8
+    ```
+
+For your model, you may need to adjust the hyperparameters and their distributions. All arguments defined in the `argparser.py` of your method should be set in this configuration file either to a fixed value (not optimized) or a distribution of values (optimized). A full list of hyperparameter configuration options can be found in the [W&B documentation](https://docs.wandb.ai/guides/sweeps/sweep-config-keys/).
+
+## Run hyperparameter optimization
+Once you defined the configuration file, you can run hyperparameter optimization using the `ldctbench-hpopt` command. The command takes two arguments: the path to the configuration file and the number of runs to execute. The number of runs determines how many times the optimization algorithm will sample hyperparameters and train the model. The more runs you specify, the more likely you are to find the optimal hyperparameters.
+
+To run ten steps of hyperparameter optimization using the configuration file described above, execute the following command:
+
+```bash
+ldctbench-hpopt --config configs/cnn10-hpopt.yaml --n_runs 10
+```
+
+After all runs are completed, this script reports the best run(1). This run can be used as `--methods` argument to the [test script][evaluate-custom-trained-models]. You can also visualize the results in the W&B dashboard by logging in to your W&B account and navigating to the respective project/sweep.
+{ .annotate }
+
+1.  What is *best* is determined from the `metric` parameter in the config file. For the example above it would be the one that maximizes the SSIM on the validation data.
+
+
+[^1]: Bergstra, James, and Yoshua Bengio. 2012. “Random Search for Hyper-Parameter Optimization.” Journal of Machine Learning Research 13 (10): 281–305.
+[^2]: Bergstra, James, Rémi Bardenet, Yoshua Bengio, and Balázs Kégl. 2011. “Algorithms for Hyper-Parameter Optimization.” In . Vol. 24.
+[^3]: Snoek, Jasper, Hugo Larochelle, and Ryan P Adams. 2012. “Practical Bayesian Optimization of Machine Learning Algorithms.” In Advances in Neural Information Processing Systems. Vol. 25.
+

--- a/ldctbench/scripts/hpopt.py
+++ b/ldctbench/scripts/hpopt.py
@@ -1,0 +1,45 @@
+import argparse
+
+import wandb
+import yaml
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default="",
+        help="Config file to use for hyperparameter optimization",
+    )
+    parser.add_argument(
+        "--n_runs",
+        type=int,
+        help="Number of steps of hyperparameter optimization",
+    )
+    opt = parser.parse_args()
+
+    # Run hyperparameter optimization
+    with open(opt.config, "r") as file:
+        sweep_config = yaml.load(file, Loader=yaml.FullLoader)  # Load sweep config
+    sweep_id = wandb.sweep(sweep_config)  # Initialize the sweep
+    print(
+        f"Starting hyperparameter optimization with {opt.n_runs} runs. Sweep ID: {sweep_id}"
+    )
+    wandb.agent(sweep_id, count=opt.n_runs)  # Start the agent
+
+    # After sweep is finished, find network with best performance
+    api = wandb.Api()
+    sweep = api.sweep(f"ldct-benchmark/{sweep_id}")
+    best_run = sweep.best_run()
+    print(
+        f"\033[1mSummary of hyperparameter optimization with sweep ID \033[92m{sweep_id}\033[0m"
+    )
+    print(f"   Number of runs: {len(sweep.runs)}")
+    print(f"   Best run: \033[92m{best_run.name}\033[0m")
+    print(f"   SSIM: {best_run.summary['SSIM']:.3f}")
+    print(f"   PSNR: {best_run.summary['PSNR']:.3f}")
+    print(f"   RMSE: {best_run.summary['RMSE']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
     - Denoise DICOMs using pretrained models: examples/denoise_dicoms.md
     - Train a custom model: examples/train_custom_model.md
     - Test models: examples/test_models.md
+    - Hyperparameter optimization: examples/hyperparameter_optimization.md
     - Evaluation using LDCT IQA: examples/ldct_iqa.md
   - Code Reference:
     - data: reference/ldctbench/data/LDCTMayo.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ docs = [
 ldctbench-download-data = "ldctbench.scripts.download_data:main"
 ldctbench-train = "ldctbench.scripts.train:main"
 ldctbench-test = "ldctbench.scripts.test:main"
+ldctbench-hpopt = "ldctbench.scripts.hpopt:main"
 [project.urls]
 GitHub = "https://github.com/eeulig/ldct-benchmark"
 Documentation = "https://eeulig.github.io/ldct-benchmark/"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -14,3 +14,8 @@ def test_entrypoint_train_is_found():
 def test_entrypoint_test_is_found():
     exit_status = os.system("ldctbench-test --help")
     assert exit_status == 0
+
+
+def test_entrypoint_hpopt_is_found():
+    exit_status = os.system("ldctbench-hpopt --help")
+    assert exit_status == 0


### PR DESCRIPTION
This PR adds hyperparamter optimization using [W&B's sweeps](https://docs.wandb.ai/tutorials/sweeps/).

- The new CL script `ldctbench-hpopt` lets you run hyperparamter optimization using a prespecified config file.
- The file `configs/cnn10-hpopt.yaml` is an example config file to optimize hyperparamters of CNN-10.
- A new example in the documentation explains how to run hyperparamter oprimization for some algorithm.